### PR TITLE
Use only last character of filename as problem ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Then, simple run `cf.py A.{lang}`, you will get the result like this:
 
     press enter to continue or <C-c> to leave.
 
+In general, the last character of the filename will be used as problem ID.
+
 ## Configurations
 The file `conf.py' contains the compile & execute commands of support
 languages, so you could add more commands to support more languages

--- a/cf.py
+++ b/cf.py
@@ -206,7 +206,7 @@ def main():
         print '>>> failed to Compile the source code!'
         sys.exit(1)
 
-    with open('{0}{1}'.format(id, conf.EXTENSION)) as test_file:
+    with open('{0}{1}'.format(id[-1], conf.EXTENSION)) as test_file:
         samples = etree.fromstring(
             '<samples>{0}</samples>'.format(test_file.read()))
         nodes = samples.getchildren()


### PR DESCRIPTION
I usually name my files `{cid}{pid}.{ext}` (e.g. `168B.py`). So this would cover this usage and the original one.
